### PR TITLE
Change Python versions: 3.9->3.10, 3.13->3.14, and 3.14->3.15

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yaml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.13"]  # Change if after Oct. 2025
+        python-version: ["3.14"]  # Change if after Oct. 2026
 
     defaults:
       run:
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13, macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.9", "3.13"]  # Change if after Oct. 2025
+        python-version: ["3.10", "3.14"]  # Change if after Oct. 2026
 
     defaults:
       run:

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 dynamic = ["version"]
 # description = ""
 # keywords = []
-requires-python = ">=3.9,<3.14"  # Change if after Oct. 2025
+requires-python = ">=3.10,<3.15"  # Change if after Oct. 2026
 # license = ""
 # license-files = [""]
 authors = [


### PR DESCRIPTION
Python 3.14 was released Oct. 7, 2025. This update changes the min/max and CI versions to be inline with 3.9 losing support, 3.14 entering its stable support window. 

Lower bound for tests and in `pyproject.toml` is now `>=3.10`, and upper bound is `<3.15`. CI linter and tests now also run on the min/max supported versions, i.e., 3.10 and 3.14.