### PR TITLE
Change macos-13 to macos-15-intel in ci

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yaml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-15-intel, macos-latest, windows-latest, ubuntu-latest]
         python-version: ["3.10", "3.14"]  # Change if after Oct. 2026
 
     defaults:


### PR DESCRIPTION
The `macos-13` runner is being deprecated. Moved to using the suggested `macos-15-intel` to keep some tests running on the x86 architecture by default.